### PR TITLE
Add Dependabot and Docker Hub configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "gomod" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,42 @@
+# name of the action
+name: publish
+
+# trigger on push events with branch main
+on:
+  push:
+    branches: [ main ]
+
+# pipeline to execute
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: clone
+        uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        with:
+          # ensures we fetch tag history for the repository
+          fetch-depth: 0
+
+      - name: install go
+        uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
+        with:
+          # use version from go.mod file
+          go-version-file: 'go.mod'
+          cache: true
+          check-latest: true
+
+      - name: build
+        env:
+          GOOS: linux
+          CGO_ENABLED: '1'
+        run: |
+          make build
+
+      - name: publish
+        uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2 # v5
+        with:
+          name: cargill/vela-aws-credentials
+          cache: true
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}


### PR DESCRIPTION
## Changes

- Add `dependabot.yml` for weekly updates to Go.
- Add `.github/workflows/publish.yml` for publishing the Docker image to hub.docker.com.