### PR TITLE
enhance(credential): support multiple profiles and append mode

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -148,6 +148,55 @@ steps:
       - aws sts get-caller-identity
 ```
 
+Example of generating AWS credentials file with custom profile name:
+
+```yaml
+steps:
+  - name: generate_aws
+    image: cargill/vela-aws-credentials:latest
+    id_request: yes
+    parameters:
+      role: "arn:aws:iam::123456123456:role/test"
+      script_write: true
+      script_format: "credential_file"
+      profile_name: "production"
+
+  - name: test_aws
+    image: amazon/aws-cli:latest
+    commands:
+      - aws sts get-caller-identity --profile production
+```
+
+Example of appending multiple profiles to a single AWS credentials file:
+
+```yaml
+steps:
+  - name: generate_dev_aws
+    image: cargill/vela-aws-credentials:latest
+    id_request: yes
+    parameters:
+      role: "arn:aws:iam::123456123456:role/dev"
+      script_write: true
+      script_format: "credential_file"
+      profile_name: "dev"
+
+  - name: generate_prod_aws
+    image: cargill/vela-aws-credentials:latest
+    id_request: yes
+    parameters:
+      role: "arn:aws:iam::123456123456:role/prod"
+      script_write: true
+      script_format: "credential_file"
+      profile_name: "prod"
+      append_config: true
+
+  - name: test_aws
+    image: amazon/aws-cli:latest
+    commands:
+      - aws sts get-caller-identity --profile dev
+      - aws sts get-caller-identity --profile prod
+```
+
 ## Parameters
 
 > **NOTE:**
@@ -170,6 +219,8 @@ The following parameters are used to configure the image:
 | `script_path`              | Path where to write script that contains AWS credentials                                                                                                                       | `false`  | `/vela/secrets/aws/setup.sh` (shell) or `/vela/secrets/aws/creds` (credential_file) | `PARAMETER_SCRIPT_PATH`<br>`AWS_CREDENTIALS_SCRIPT_PATH`                           |
 | `script_write`             | If the credentials script should be created.                                                                                                                                   | `false`  | `false`                                                                             | `PARAMETER_SCRIPT_WRITE`<br>`AWS_CREDENTIALS_SCRIPT_WRITE`                         |
 | `script_format`            | Format of file to write (shell or credential_file)                                                                                                                             | `false`  | `N/A`                                                                               | `PARAMETER_SCRIPT_FORMAT`<br>`AWS_CREDENTIALS_SCRIPT_FORMAT`                       |
+| `append_config`            | When using credential_file format, append to existing file instead of overwriting. Fails if profile already exists.                                                            | `false`  | `N/A`                                                                               | `PARAMETER_APPEND_CONFIG`<br>`AWS_CREDENTIALS_APPEND_CONFIG`                       |
+| `profile_name`             | When using credential_file format, specify the profile name to use instead of 'default'.                                                                                       | `false`  | `default` (when not specified)                                                     | `PARAMETER_PROFILE_NAME`<br>`AWS_CREDENTIALS_PROFILE_NAME`                         |
 | `inline_session_policy`    | An IAM policy in JSON format that you want to use as an inline session policy when assuming the IAM role.                                                                      | `false`  | `N/A`                                                                               | `PARAMETER_INLINE_SESSION_POLICY`<br>`AWS_CREDENTIALS_INLINE_SESSION_POLICY`       |
 | `managed_session_policies` | List of ARNs of the IAM managed policies that you want to use as managed session policies when assuming the IAM role. The policies must exist in the same account as the role. | `false`  | `N/A`                                                                               | `PARAMETER_MANAGED_SESSION_POLICIES`<br>`AWS_CREDENTIALS_MANAGED_SESSION_POLICIES` |
 

--- a/cmd/vela-aws-credentials/main.go
+++ b/cmd/vela-aws-credentials/main.go
@@ -139,6 +139,16 @@ func main() {
 			Usage:   "if the credentials script should be created",
 			Value:   false,
 		},
+		&cli.BoolFlag{
+			EnvVars: []string{"PARAMETER_APPEND_CONFIG", "AWS_CREDENTIALS_APPEND_CONFIG"},
+			Name:    "append_config",
+			Usage:   "append to existing credential file instead of overwriting (credential_file format only)",
+		},
+		&cli.StringFlag{
+			EnvVars: []string{"PARAMETER_PROFILE_NAME", "AWS_CREDENTIALS_PROFILE_NAME"},
+			Name:    "profile_name",
+			Usage:   "profile name to use in credential file (credential_file format only)",
+		},
 	}
 
 	err := app.Run(os.Args)
@@ -175,6 +185,21 @@ func run(c *cli.Context) error {
 		"registry": "https://hub.docker.com/r/cargill/vela-aws-credentials",
 	}).Info("Vela AWS Credentials Config")
 
+	// Handle pointer fields for AppendConfig and ProfileName
+	var appendConfig *bool
+	var profileName *string
+
+	// Only set pointers if flags are explicitly provided
+	if c.IsSet("append_config") {
+		val := c.Bool("append_config")
+		appendConfig = &val
+	}
+
+	if c.IsSet("profile_name") {
+		val := c.String("profile_name")
+		profileName = &val
+	}
+
 	// create the plugin
 	p := &plugin.Config{
 		Audience:     c.String("audience"),
@@ -182,6 +207,8 @@ func run(c *cli.Context) error {
 		ScriptPath:   c.String("script_path"),
 		ScriptFormat: c.String("script_format"),
 		ScriptWrite:  c.Bool("script_write"),
+		AppendConfig: appendConfig,
+		ProfileName:  profileName,
 		AWS: &plugin.AWS{
 			Region:                 c.String("aws.region"),
 			Role:                   c.String("aws.role"),

--- a/pkg/plugin/aws_test.go
+++ b/pkg/plugin/aws_test.go
@@ -17,6 +17,8 @@ func TestConfig_WriteCreds(t *testing.T) {
 	type args struct {
 		creds        *aws.Credentials
 		scriptFormat string
+		appendConfig *bool
+		profileName  *string
 	}
 
 	tests := []struct {
@@ -51,17 +53,33 @@ func TestConfig_WriteCreds(t *testing.T) {
 			want:    "testdata/script.credential_file",
 			wantErr: false,
 		},
+		{
+			name: "credential_file_with_custom_profile",
+			args: args{
+				creds: &aws.Credentials{
+					AccessKeyID:     "ACCESS_KEY_ID",
+					SecretAccessKey: "SECRET_ACCESS_KEY",
+					SessionToken:    "SESSION_TOKEN",
+				},
+				scriptFormat: "credential_file",
+				profileName:  stringPtr("production"),
+			},
+			want:    "testdata/script.credential_file_custom_profile",
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			scriptPath := filepath.Join(t.TempDir(), fmt.Sprintf("script.%s", tt.args.scriptFormat))
 			c := &Config{
-				ScriptPath: scriptPath,
+				ScriptPath:   scriptPath,
+				ScriptFormat: tt.args.scriptFormat,
+				AppendConfig: tt.args.appendConfig,
+				ProfileName:  tt.args.profileName,
 				AWS: &AWS{
 					Region: "us-east-1",
 				},
-				ScriptFormat: tt.args.scriptFormat,
 			}
 
 			err := c.WriteCreds(tt.args.creds)
@@ -79,6 +97,91 @@ func TestConfig_WriteCreds(t *testing.T) {
 
 			if diff := cmp.Diff(string(expected), string(got)); diff != "" {
 				t.Errorf("WriteCreds() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestConfig_WriteCreds_AppendConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		existingFile string
+		profileName  string
+		expectedFile string
+		wantErr      bool
+	}{
+		{
+			name:         "append_to_nonexistent_file",
+			existingFile: "",
+			profileName:  "default",
+			expectedFile: "testdata/script.credential_file",
+			wantErr:      false,
+		},
+		{
+			name: "append_new_profile",
+			existingFile: `[existing]
+aws_access_key_id=EXISTING_KEY
+aws_secret_access_key=EXISTING_SECRET
+aws_session_token=EXISTING_TOKEN`,
+			profileName:  "default",
+			expectedFile: "testdata/script.credential_file_append_new",
+			wantErr:      false,
+		},
+		{
+			name: "fail_when_profile_exists",
+			existingFile: `[default]
+aws_access_key_id=OLD_KEY
+aws_secret_access_key=OLD_SECRET
+aws_session_token=OLD_TOKEN`,
+			profileName: "default",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+			scriptPath := filepath.Join(tempDir, "credentials")
+
+			// Create existing file if specified
+			if tt.existingFile != "" {
+				err := os.WriteFile(scriptPath, []byte(tt.existingFile), 0600)
+				assert.NoError(t, err)
+			}
+
+			c := &Config{
+				ScriptPath:   scriptPath,
+				ScriptFormat: "credential_file",
+				AppendConfig: boolPtr(true),
+				ProfileName:  stringPtr(tt.profileName),
+				AWS: &AWS{
+					Region: "us-east-1",
+				},
+			}
+
+			creds := &aws.Credentials{
+				AccessKeyID:     "ACCESS_KEY_ID",
+				SecretAccessKey: "SECRET_ACCESS_KEY",
+				SessionToken:    "SESSION_TOKEN",
+			}
+
+			err := c.WriteCreds(creds)
+			if tt.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+
+			// Read expected content
+			expected, err := os.ReadFile(tt.expectedFile)
+			assert.NoError(t, err)
+
+			// Read actual content
+			got, err := os.ReadFile(scriptPath)
+			assert.NoError(t, err)
+
+			if diff := cmp.Diff(string(expected), string(got)); diff != "" {
+				t.Errorf("WriteCreds() append mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -17,6 +17,8 @@ type (
 		ScriptPath   string
 		ScriptFormat string
 		ScriptWrite  bool
+		AppendConfig *bool
+		ProfileName  *string
 		AWS          *AWS
 		Vela         *Vela
 	}
@@ -87,6 +89,15 @@ func (c *Config) Validate() error {
 	supportedFormats := []string{"shell", "credential_file"}
 	if !slices.Contains(supportedFormats, c.ScriptFormat) {
 		return fmt.Errorf("only script formats of %s are supported", supportedFormats)
+	}
+
+	// Validate AppendConfig and ProfileName are only used with credential_file format
+	if c.AppendConfig != nil && c.ScriptFormat != "credential_file" {
+		return fmt.Errorf("append_config can only be used with credential_file format, but script_format is set to %s", c.ScriptFormat)
+	}
+
+	if c.ProfileName != nil && c.ScriptFormat != "credential_file" {
+		return fmt.Errorf("profile_name can only be used with credential_file format, but script_format is set to %s", c.ScriptFormat)
 	}
 
 	if c.ScriptPath == "" {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -87,6 +87,88 @@ func TestConfig_Validate(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "AppendConfig set with shell format should error",
+			config: &Config{
+				AWS: &AWS{
+					Role:                "testRole",
+					RoleDurationSeconds: 3600,
+				},
+				Vela: &Vela{
+					RequestToken:    "testToken",
+					RequestTokenURL: "http://127.0.0.1",
+				},
+				ScriptFormat: "shell",
+				AppendConfig: boolPtr(true),
+			},
+			wantErr: true,
+		},
+		{
+			name: "ProfileName set with shell format should error",
+			config: &Config{
+				AWS: &AWS{
+					Role:                "testRole",
+					RoleDurationSeconds: 3600,
+				},
+				Vela: &Vela{
+					RequestToken:    "testToken",
+					RequestTokenURL: "http://127.0.0.1",
+				},
+				ScriptFormat: "shell",
+				ProfileName:  stringPtr("custom"),
+			},
+			wantErr: true,
+		},
+		{
+			name: "AppendConfig and ProfileName set with credential_file format should pass",
+			config: &Config{
+				AWS: &AWS{
+					Role:                "testRole",
+					RoleDurationSeconds: 3600,
+				},
+				Vela: &Vela{
+					RequestToken:    "testToken",
+					RequestTokenURL: "http://127.0.0.1",
+				},
+				ScriptFormat: "credential_file",
+				AppendConfig: boolPtr(true),
+				ProfileName:  stringPtr("custom"),
+			},
+			wantErr: false,
+		},
+		{
+			name: "AppendConfig false with credential_file should pass",
+			config: &Config{
+				AWS: &AWS{
+					Role:                "testRole",
+					RoleDurationSeconds: 3600,
+				},
+				Vela: &Vela{
+					RequestToken:    "testToken",
+					RequestTokenURL: "http://127.0.0.1",
+				},
+				ScriptFormat: "credential_file",
+				AppendConfig: boolPtr(false),
+			},
+			wantErr: false,
+		},
+		{
+			name: "AppendConfig and ProfileName nil should pass with any format",
+			config: &Config{
+				AWS: &AWS{
+					Role:                "testRole",
+					RoleDurationSeconds: 3600,
+				},
+				Vela: &Vela{
+					RequestToken:    "testToken",
+					RequestTokenURL: "http://127.0.0.1",
+				},
+				ScriptFormat: "shell",
+				AppendConfig: nil,
+				ProfileName:  nil,
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/plugin/test_helpers.go
+++ b/pkg/plugin/test_helpers.go
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package plugin
+
+// Helper functions to create pointers for test cases
+func boolPtr(b bool) *bool {
+	return &b
+}
+
+func stringPtr(s string) *string {
+	return &s
+}

--- a/pkg/plugin/testdata/script.credential_file_append_new
+++ b/pkg/plugin/testdata/script.credential_file_append_new
@@ -1,0 +1,8 @@
+[existing]
+aws_access_key_id=EXISTING_KEY
+aws_secret_access_key=EXISTING_SECRET
+aws_session_token=EXISTING_TOKEN
+[default]
+aws_access_key_id=ACCESS_KEY_ID
+aws_secret_access_key=SECRET_ACCESS_KEY
+aws_session_token=SESSION_TOKEN

--- a/pkg/plugin/testdata/script.credential_file_custom_profile
+++ b/pkg/plugin/testdata/script.credential_file_custom_profile
@@ -1,0 +1,4 @@
+[production]
+aws_access_key_id=ACCESS_KEY_ID
+aws_secret_access_key=SECRET_ACCESS_KEY
+aws_session_token=SESSION_TOKEN


### PR DESCRIPTION
Add functionality to create AWS credential files with custom profile names and append to existing files. Fails if profile already exists to prevent accidental overwrites.