### PR TITLE
fix: typo with default script format

### DIFF
--- a/pkg/plugin/variables.go
+++ b/pkg/plugin/variables.go
@@ -41,7 +41,7 @@ var (
 			FilePath: "/vela/parameters/aws-credentials/script_format,/vela/secrets/aws-credentials/script_format",
 			Name:     FlagScriptFormat,
 			Usage:    "format of AWS credentials script (ScriptFormatShell or ScriptFormatCredentialFile)",
-			Value:    "ScriptFormatShell",
+			Value:    ScriptFormatShell,
 		},
 		&cli.BoolFlag{
 			EnvVars: []string{"PARAMETER_SCRIPT_WRITE", "AWS_CREDENTIALS_SCRIPT_WRITE"},

--- a/pkg/plugin/variables.go
+++ b/pkg/plugin/variables.go
@@ -40,7 +40,7 @@ var (
 			EnvVars:  []string{"PARAMETER_SCRIPT_FORMAT", "AWS_CREDENTIALS_SCRIPT_FORMAT"},
 			FilePath: "/vela/parameters/aws-credentials/script_format,/vela/secrets/aws-credentials/script_format",
 			Name:     FlagScriptFormat,
-			Usage:    "format of AWS credentials script (ScriptFormatShell or ScriptFormatCredentialFile)",
+			Usage:    "format of AWS credentials script (shell or credential_file)",
 			Value:    ScriptFormatShell,
 		},
 		&cli.BoolFlag{


### PR DESCRIPTION
Based off of https://github.com/Cargill/vela-aws-credentials/pull/227

This change fixes a typo I made in the previous PR.